### PR TITLE
Change hash to allow questions to be asked multiple times

### DIFF
--- a/text2qti/quiz.py
+++ b/text2qti/quiz.py
@@ -262,7 +262,10 @@ class Question(object):
         self.correct_feedback_html_xml: Optional[str] = None
         self.incorrect_feedback_raw: Optional[str] = None
         self.incorrect_feedback_html_xml: Optional[str] = None
-        h = hashlib.blake2b(self.question_html_xml.encode('utf8'))
+        # Hash is based on title and question description so that a question with the same description
+        # can be asked multiple times in the same group
+        data = self.title_xml + self.question_html_xml
+        h = hashlib.blake2b(data.encode('utf8'))
         self.hash_digest = h.digest()
         self.id = h.hexdigest()[:64]
         self.md = md
@@ -990,9 +993,9 @@ class Quiz(object):
                             points=self._next_question_attr.get('points'),
                             md=self.md)
         self._next_question_attr = {}
-        if question.question_html_xml in self.question_set:
+        if question.id in self.question_set:
             raise Text2qtiError('Duplicate question')
-        self.question_set.add(question.question_html_xml)
+        self.question_set.add(question.id)
         self.questions_and_delims.append(question)
         if self._current_group is not None:
             self._current_group.append_question(question)


### PR DESCRIPTION
Issue: Questions with the same description are not allowed because hash would create the same id and weird things happen afterward
Fix: Change the hash to be based on title and question description

Can now create questions with the same description but different title as follows in attached screenshot
![Screen Shot 2020-11-30 at 12 04 04 PM](https://user-images.githubusercontent.com/23159917/100660731-475d0c00-3307-11eb-845e-006d5fc84acc.png)


`Known Issue #3: multiple questions in a Group can't have the same question text
Even if it has different options - Can we find a way to remedy this?
Possibly can we add the ability to name questions in a Group? You can do this in Canvas, but I am unaware how this is set in the QTI or if there is a field in the Markdown we can use`